### PR TITLE
Fixing link on 'Try for Free' button on pricing page

### DIFF
--- a/src/app/public/pricing/pricing.component.html
+++ b/src/app/public/pricing/pricing.component.html
@@ -13,7 +13,7 @@
         </ul>
       </mat-card-content>
       <mat-card-actions>
-        <a href="https://zestfuldata.com/demo" mat-flat-button color="primary">Try for Free</a>
+        <a [routerLink]="['/demo']" mat-flat-button color="primary">Try for Free</a>
       </mat-card-actions>
     </mat-card>
   </div>


### PR DESCRIPTION
It should be a routerlink not a regular link